### PR TITLE
Automatyzacja załączania zależności

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,14 +7,30 @@ buildscript {
         maven {
             url "http://dl.bintray.com/jetbrains/intellij-plugin-service"
         }
+        flatDir {
+            dirs 'lib'
+        }
+
     }
     dependencies {
         classpath "gradle.plugin.org.jetbrains:gradle-intellij-plugin:0.1.10"
+
     }
 
 }
 
 apply plugin: 'idea'
 apply plugin: 'java'
+
+dependencies {
+    runtime files('lib/pitest-1.1.11.jar')
+    runtime files('lib/pitest-command-line-1.1.11.jar')
+    runtime files('lib/junit-4.12.jar')
+    runtime files('lib/hamcrest-core-1.3.jar')
+
+}
+
 apply plugin: 'org.jetbrains.intellij'
+
+
 

--- a/src/main/java/PitestRunProfilState.java
+++ b/src/main/java/PitestRunProfilState.java
@@ -11,7 +11,9 @@ import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.util.PathUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.jps.PathUtils;
 
+import java.nio.file.Paths;
 import java.util.List;
 
 public class PitestRunProfilState extends JavaCommandLineState {
@@ -38,8 +40,14 @@ public class PitestRunProfilState extends JavaCommandLineState {
 
         myNewParams.getClassPath().add(PathUtil.getJarPathForClass(getClass()));
         myNewParams.getClassPath().add(getEnvironment().getProject().getBaseDir().getPath());
+        String pluginClasspath = PathUtil.getParentPath(PathUtil.getJarPathForClass(this.getClass()));
+        myNewParams.getClassPath().add(pluginClasspath + "/lib/hamcrest-core-1.3.jar");
+        myNewParams.getClassPath().add(pluginClasspath + "/lib/junit-4.12.jar");
+        myNewParams.getClassPath().add(pluginClasspath + "/lib/pitest-1.1.11.jar");
+        myNewParams.getClassPath().add(pluginClasspath + "/lib/pitest-command-line-1.1.11.jar");
 
         JavaParametersUtil.configureModule(actualModule, myNewParams, JavaParameters.JDK_AND_CLASSES_AND_TESTS, null);
+
         //JavaParametersUtil.configureConfiguration(myNewParams, importantConfiguration);
 
 //        Module[] list = ModuleManager.getInstance(getEnvironment().getProject()).getModules();


### PR DESCRIPTION
Udało się,
jednak samo dodawanie runtime'ów w grandlu nie pomogło;
może być konieczne, aby w Project Structure samego projektu pluginu,
do dependencies dodać te jary, aby zostały skopiowane podczas kompilacji pluginu do folderu /lib/ w docelowej lokalizacji skompilowanych danych pluginu